### PR TITLE
fix(ci): updated image push endpoint and added placeholder username

### DIFF
--- a/.github/workflows/jeliasson-nginx.yml
+++ b/.github/workflows/jeliasson-nginx.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - jeliasson-nginx
-      - temp
 
     paths:
 
@@ -55,7 +54,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: jeliasson
+          username: needs-to-be-updated
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -68,5 +67,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/jeliasson-nginx.yml
+++ b/.github/workflows/jeliasson-nginx.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - jeliasson-nginx
-      - update-ci
 
     paths:
 
@@ -68,5 +67,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/redwoodjs/test-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/redwoodjs/test-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/jeliasson-nginx.yml
+++ b/.github/workflows/jeliasson-nginx.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - jeliasson-nginx
+      - update-ci
 
     paths:
 
@@ -54,7 +55,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: needs-to-be-updated
+          username: thedavidprice
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -67,5 +68,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/test-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/test-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/standal-ce-nginx.yml
+++ b/.github/workflows/standal-ce-nginx.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - standal-ce-nginx
-      - temp
 
     paths:
 
@@ -55,7 +54,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: jeliasson
+          username: needs-to-be-updated
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -68,5 +67,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/standal-ce-nginx.yml
+++ b/.github/workflows/standal-ce-nginx.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: needs-to-be-updated
+          username: thedavidprice
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -67,5 +67,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/standal-cli-both.yml
+++ b/.github/workflows/standal-cli-both.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - standal-cli-both
-      - temp
 
     paths:
       # Implementation specific
@@ -52,7 +51,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: jeliasson
+          username: needs-to-be-updated
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -65,5 +64,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/standal-cli-both.yml
+++ b/.github/workflows/standal-cli-both.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: needs-to-be-updated
+          username: thedavidprice
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -64,5 +64,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -60,7 +60,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: jeliasson
+          username: needs-to-be-updated
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -73,5 +73,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/jeliasson/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -60,7 +60,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: needs-to-be-updated
+          username: thedavidprice
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Docker build
@@ -73,5 +73,5 @@ jobs:
             NODE_ENV=${{ env.NODE_ENV }}
             RUNTIME_ENV=${{ env.RUNTIME_ENV }}
           tags: |
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
-            ghcr.io/redwoodjs/${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:latest
+            ghcr.io/redwoodjs/docker-${{ env.IMAGE_PREFIX }}-${{ matrix.platform }}-${{ env.RUNTIME_ENV }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ docker run \
       -it \
       --rm \
       -p 8911:8911 \
-      ghcr.io/redwoodjs/jeliasson-nginx-api-dev:latest
+      ghcr.io/redwoodjs/docker-jeliasson-nginx-api-dev:latest
 
 # Web
 docker run \
       -it \
       --rm \
       -p 8910:8910 \
-      ghcr.io/redwoodjs/jeliasson-nginx-web-dev:latest
+      ghcr.io/redwoodjs/docker-jeliasson-nginx-web-dev:latest
 ```
 
 ### `standal-ce-nginx`
@@ -110,14 +110,14 @@ docker run \
       -it \
       --rm \
       -p 8911:8911 \
-      ghcr.io/redwoodjs/standal-ce-nginx-api-dev:latest
+      ghcr.io/redwoodjs/docker-standal-ce-nginx-api-dev:latest
 
 # Web
 docker run \
       -it \
       --rm \
       -p 8910:8910 \
-      ghcr.io/redwoodjs/standal-ce-nginx-web-dev:latest
+      ghcr.io/redwoodjs/docker-standal-ce-nginx-web-dev:latest
 ```
 
 ### `standal-cli-both`
@@ -162,7 +162,7 @@ docker run \
       -it \
       --rm \
       -p 8910:8910 \
-      ghcr.io/redwoodjs/standal-cli-both-dev:latest
+      ghcr.io/redwoodjs/docker-standal-cli-both-dev:latest
 ```
 
 ## Development
@@ -182,16 +182,16 @@ LABEL org.opencontainers.image.source=https://github.com/redwoodjs/docker
 
 Published Docker images to GitHub Container Registry should preferably be named;
 
-- `<prefix>-api-dev` for api build with development as runtime env.
-- `<prefix>-web-dev` for web build with development as runtime env.
-- `<prefix>-both-dev` for api and web build with development as runtime env.
-- `<prefix>-api-prod` for api build with production as runtime env.
-- `<prefix>-web-prod` for web build with production as runtime env.
-- `<prefix>-both-prod` for api and web build with production as runtime env.
+- `docker-<prefix>-api-dev` for api build with development as runtime env.
+- `docker-<prefix>-web-dev` for web build with development as runtime env.
+- `docker-<prefix>-both-dev` for api and web build with development as runtime env.
+- `docker-<prefix>-api-prod` for api build with production as runtime env.
+- `docker-<prefix>-web-prod` for web build with production as runtime env.
+- `docker-<prefix>-both-prod` for api and web build with production as runtime env.
 
 e.g.
 
-- `jeliasson-nginx-web-dev`
+- `docker-jeliasson-nginx-web-dev`
 
 ### CI
 


### PR DESCRIPTION
#### Questions

- [x] Do Redwood have a "service account" that we can leverage for image push? ([Reference](https://github.com/jeliasson/redwoodjs-docker/blob/update-ci/.github/workflows/jeliasson-nginx.yml#L57)) 
- [x] Should we prefix the new images with something? For example, `docker-` that would become `docker-jeliasson-nginx` instead of `jeliasson-nginx` ([Reference](https://github.com/redwoodjs/docker/blob/main/.github/workflows/jeliasson-nginx.yml#L33))

/cc @thedavidprice @realStandal 